### PR TITLE
[BUGFIX] Handle uncaught Throwable exceptions

### DIFF
--- a/src/Resources/Event.php
+++ b/src/Resources/Event.php
@@ -52,7 +52,7 @@ class Event extends BaseRestResource
                                 $eventMap[$serviceName] = $map;
                             }
                         }
-                    } catch (\Exception $ex) {
+                    } catch (\Throwable $ex) {
                         Log::info("Failed to build event map for service $serviceName. {$ex->getMessage()}");
                     }
                 }


### PR DESCRIPTION
We updated the exception handling mechanism by using the base interface `Throwable` as the error class. Previously, some of our services were throwing unprocessed errors, which caused issues with loading Service Events from all services. One example was Couchbase, which was attempting to create an instance of a non-existent class. With this update, we catch any errors that occur and provide a result to the UI, even if an error occurs during processing.