### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,16 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
+    "php":                   "^8.3",
+    "laravel/helpers":       "^1.8",
     "dreamfactory/df-core":  "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework":    "^13.7",
+    "mockery/mockery":      "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "orchestra/testbench":  "^11.0",
+    "phpunit/phpunit":      "^11.5.3"
   },
   "autoload":    {
     "psr-4": {


### PR DESCRIPTION
## Summary

Laravel 13 compatibility upgrade for df-system. Composer-only dep matrix bump — no source files needed changes.

Part of the Laravel 11→13 upgrade campaign. Pilot: dreamfactorysoftware/df-core#162. Sibling PRs land in parallel: df-user, df-database, df-sqldb.

## Changes

- `composer.json`:
  - `require`: `php → ^8.3`, add `laravel/helpers: ^1.8` (covers heavy `array_get`/`camel_case` usage in src/)
  - `require-dev`: `laravel/framework: ^13.7`, `phpunit: ^11.5.3`, `orchestra/testbench: ^11.0`, `mockery: ^1.6`, `nunomaduro/collision: ^8.6`

`laravel/framework` deliberately stays in `require-dev` only — package remains framework-agnostic in production.

## Test plan

- [x] `composer validate --strict` — valid
- [x] `composer install` against L13 dep matrix — resolves cleanly with df-core path-repo (laravel/framework v13.7.0, phpunit 11.5.55, testbench v11.1.0)
- [x] `php -l` clean over src/ + tests/
- [x] `vendor/bin/phpunit` — 100 tests load under PHPUnit 11; failures are df-core's TestCase needing a host-app bootstrap, not df-system regressions
- [x] Stage 2 host-app integration via `shift-173254` worktree — autoload + class_exists smoke for all df-system public classes passes under Laravel 13.7.0
- [x] Independent code-review-expert pass: PASS (high confidence)

## Notes

- Wave 0 invariants verified: no `DispatchesJobs`, no `CorsService` reparenting, no `setupBeforeClass` typos, no LSP-violating return types, no removed `getDates()` overrides.
- WIP /provision feature was preserved via `git stash push -u` — recoverable from `stash@{0}` on master (do not lose).